### PR TITLE
Add version 2 of the symfony/http-client-contracts dependency as possible requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "require": {
         "php": "^7.1.3",
         "symfony/cache": "^4.2",
-        "symfony/http-client-contracts": "^1.1"
+        "symfony/http-client-contracts": "^1.1 || ^2"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.15",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "66c60ff50d6c96bc56ecffb17149c527",
+    "content-hash": "481ee0c04c2c8a2c3712b5bf09455680",
     "packages": [
         {
             "name": "psr/cache",
@@ -286,20 +286,20 @@
         },
         {
             "name": "symfony/http-client-contracts",
-            "version": "v1.1.5",
+            "version": "v1.1.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-client-contracts.git",
-                "reference": "e1924aea9c70ae3e69fff05afa3cb8ce541bf3bb"
+                "reference": "7e86f903f9720d0caa7688f5c29a2de2d77cbb89"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-client-contracts/zipball/e1924aea9c70ae3e69fff05afa3cb8ce541bf3bb",
-                "reference": "e1924aea9c70ae3e69fff05afa3cb8ce541bf3bb",
+                "url": "https://api.github.com/repos/symfony/http-client-contracts/zipball/7e86f903f9720d0caa7688f5c29a2de2d77cbb89",
+                "reference": "7e86f903f9720d0caa7688f5c29a2de2d77cbb89",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1.3"
+                "php": ">=7.1.3"
             },
             "suggest": {
                 "symfony/http-client-implementation": ""
@@ -308,6 +308,10 @@
             "extra": {
                 "branch-alias": {
                     "dev-master": "1.1-dev"
+                },
+                "thanks": {
+                    "name": "symfony/contracts",
+                    "url": "https://github.com/symfony/contracts"
                 }
             },
             "autoload": {
@@ -339,7 +343,24 @@
                 "interoperability",
                 "standards"
             ],
-            "time": "2019-06-17T17:43:54+00:00"
+            "support": {
+                "source": "https://github.com/symfony/http-client-contracts/tree/v1.1.10"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-08-17T09:35:39+00:00"
         },
         {
             "name": "symfony/service-contracts",
@@ -3158,5 +3179,6 @@
     "platform": {
         "php": "^7.1.3"
     },
-    "platform-dev": []
+    "platform-dev": [],
+    "plugin-api-version": "2.0.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -2577,40 +2577,41 @@
         },
         {
             "name": "symfony/http-client",
-            "version": "v4.3.3",
+            "version": "v4.4.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-client.git",
-                "reference": "7759fabfbdf7f57a1d29655550b49c4ff04891a5"
+                "reference": "7196e9b38e4d15947e664f6f455614d4ede6ca17"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-client/zipball/7759fabfbdf7f57a1d29655550b49c4ff04891a5",
-                "reference": "7759fabfbdf7f57a1d29655550b49c4ff04891a5",
+                "url": "https://api.github.com/repos/symfony/http-client/zipball/7196e9b38e4d15947e664f6f455614d4ede6ca17",
+                "reference": "7196e9b38e4d15947e664f6f455614d4ede6ca17",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1.3",
+                "php": ">=7.1.3",
                 "psr/log": "^1.0",
-                "symfony/http-client-contracts": "^1.1.4",
-                "symfony/polyfill-php73": "^1.11"
+                "symfony/http-client-contracts": "^1.1.10|^2",
+                "symfony/polyfill-php73": "^1.11",
+                "symfony/service-contracts": "^1.0|^2"
             },
             "provide": {
+                "php-http/async-client-implementation": "*",
+                "php-http/client-implementation": "*",
                 "psr/http-client-implementation": "1.0",
                 "symfony/http-client-implementation": "1.1"
             },
             "require-dev": {
+                "guzzlehttp/promises": "^1.3.1",
                 "nyholm/psr7": "^1.0",
+                "php-http/httplug": "^1.0|^2.0",
                 "psr/http-client": "^1.0",
-                "symfony/http-kernel": "^4.3",
-                "symfony/process": "^4.2"
+                "symfony/dependency-injection": "^4.3|^5.0",
+                "symfony/http-kernel": "^4.4.13",
+                "symfony/process": "^4.2|^5.0"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "4.3-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Symfony\\Component\\HttpClient\\": ""
@@ -2635,7 +2636,24 @@
             ],
             "description": "Symfony HttpClient component",
             "homepage": "https://symfony.com",
-            "time": "2019-07-24T10:16:23+00:00"
+            "support": {
+                "source": "https://github.com/symfony/http-client/tree/v4.4.17"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-11-28T13:23:02+00:00"
         },
         {
             "name": "symfony/options-resolver",

--- a/tests/AuthZeroAuthenticatingHttpClientTest.php
+++ b/tests/AuthZeroAuthenticatingHttpClientTest.php
@@ -77,12 +77,13 @@ class AuthZeroAuthenticatingHttpClientTest extends TestCase
         $response = $this->httpClient->request('GET', 'https://superbrave.nl/api');
 
         $this->assertSame(
-            array(
-                'authorization' => array(
-                    sprintf('Bearer %s', $accessToken),
-                ),
-            ),
-            $response->getRequestOptions()['headers']
+            [
+                'accept' => ['Accept: */*'],
+                'authorization' => [
+                    sprintf('Authorization: Bearer %s', $accessToken),
+                ],
+            ],
+            $response->getRequestOptions()['normalized_headers']
         );
     }
 
@@ -106,24 +107,26 @@ class AuthZeroAuthenticatingHttpClientTest extends TestCase
         $response = $this->httpClient->request('GET', 'https://superbrave.nl/api');
 
         $this->assertSame(
-            array(
-                'authorization' => array(
-                    sprintf('Bearer %s', $accessToken),
-                ),
-            ),
-            $response->getRequestOptions()['headers']
+            [
+                'accept' => ['Accept: */*'],
+                'authorization' => [
+                    sprintf('Authorization: Bearer %s', $accessToken),
+                ],
+            ],
+            $response->getRequestOptions()['normalized_headers']
         );
         $this->assertSame('{"message": "Response from actual API."}', $response->getContent());
 
         $response = $this->httpClient->request('GET', 'https://superbrave.nl/api');
 
         $this->assertSame(
-            array(
-                'authorization' => array(
-                    sprintf('Bearer %s', $accessToken),
-                ),
-            ),
-            $response->getRequestOptions()['headers']
+            [
+                'accept' => ['Accept: */*'],
+                'authorization' => [
+                    sprintf('Authorization: Bearer %s', $accessToken),
+                ],
+            ],
+            $response->getRequestOptions()['normalized_headers']
         );
         $this->assertSame('{"message": "Another response from actual API."}', $response->getContent());
     }
@@ -168,8 +171,10 @@ class AuthZeroAuthenticatingHttpClientTest extends TestCase
         $response = $this->httpClient->request('GET', 'https://superbrave.nl/api');
 
         $this->assertSame(
-            array(),
-            $response->getRequestOptions()['headers']
+            [
+                'accept' => ['Accept: */*'],
+            ],
+            $response->getRequestOptions()['normalized_headers']
         );
     }
 
@@ -191,8 +196,10 @@ class AuthZeroAuthenticatingHttpClientTest extends TestCase
         $response = $this->httpClient->request('GET', 'https://superbrave.nl/api');
 
         $this->assertSame(
-            array(),
-            $response->getRequestOptions()['headers']
+            [
+                'accept' => ['Accept: */*'],
+            ],
+            $response->getRequestOptions()['normalized_headers']
         );
     }
 


### PR DESCRIPTION
This PR adds version 2 as a possible requirement. The only change made in version 2 is the HTTP client interfaces being made not experimental.